### PR TITLE
Add config to auto import files before linting

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -30,6 +30,12 @@ module.exports =
       default: []
       items:
         type: 'string'
+    autoImportFiles:
+      type: 'array'
+      description: 'Auto import these files before linting. Separated by \',\'.'
+      default: []
+      items:
+        type: 'string'
 
   activate: ->
     console.log 'activate linter-less' if atom.inDevMode()

--- a/lib/linter-less-provider.coffee
+++ b/lib/linter-less-provider.coffee
@@ -33,6 +33,11 @@ LinterLess =
           lineOffset++
           text = "#{variable}: 0;\n#{text}"
 
+      if files = @config 'autoImportFiles'
+        for file in files
+          lineOffset++
+          text = "@import \"#{file}\";\n#{text}"
+
       @lessParse text, filePath, (err) ->
 
         return resolve([]) unless err
@@ -56,7 +61,7 @@ LinterLess =
     parser = new less.Parser(
       verbose: false
       silent: true
-      paths: [cwd, @config('includePath')...]
+      paths: [cwd, atom.project.getPaths()..., @config('includePath')...]
       filename: filePath
     )
 

--- a/spec/files/variables.less
+++ b/spec/files/variables.less
@@ -1,0 +1,1 @@
+@fontSize: 20px;

--- a/spec/linter-less-spec.coffee
+++ b/spec/linter-less-spec.coffee
@@ -105,3 +105,16 @@ describe "Lint less", ->
           .then (messages) ->
 
             expect(messages.length).toEqual(0)
+
+    describe "auto import files", ->
+
+      it 'returns no error', ->
+
+        atom.config.set("linter-less.autoImportFiles", ["files/variables.less"])
+
+        waitsForPromise ->
+          atom.workspace.open('./files/error-undefined-variable.less')
+            .then (editor) -> LinterLessProvider.lint(editor)
+            .then (messages) ->
+
+              expect(messages.length).toEqual(0)


### PR DESCRIPTION
This is an attempt to solve the problem with undefined variables from imported file seen in #6 and #12.
It adds a config to declare files to be imported before linting.

if you import all of your less files in a `main.less` or `index.less` you just need to auto import this file.
